### PR TITLE
Benchmark Detailed: paginate by run cycles (Sunday cut)

### DIFF
--- a/internal/store/interface.go
+++ b/internal/store/interface.go
@@ -301,6 +301,17 @@ type BenchmarkStore interface {
 	// ordered oldest first. Returns an empty slice if no runs exist.
 	GetVerdictTrend(ctx context.Context, agentID string, weeks int) ([]string, error)
 
+	// ListRunCycles returns the distinct week-start timestamps (Sunday 00:00 local time,
+	// stored as UTC) for all benchmark runs, ordered newest first.
+	// Each returned time is the start of the ISO week (Sunday) that contains at least
+	// one run_at value in the database.
+	// limit=0 returns all cycles; offset skips the first N cycles for pagination.
+	ListRunCycles(ctx context.Context, loc *time.Location, limit, offset int) ([]time.Time, error)
+
+	// QueryRunsInWindow returns all benchmark runs whose run_at falls within
+	// [since, until) (inclusive start, exclusive end), ordered by run_at DESC.
+	QueryRunsInWindow(ctx context.Context, since, until time.Time) ([]BenchmarkRun, error)
+
 	// Close releases all resources held by the store.
 	Close() error
 }

--- a/internal/store/interface_test.go
+++ b/internal/store/interface_test.go
@@ -274,6 +274,12 @@ func (m *mockBenchmarkStore) ListAgents(ctx context.Context) ([]string, error) {
 func (m *mockBenchmarkStore) GetVerdictTrend(ctx context.Context, agentID string, weeks int) ([]string, error) {
 	return nil, nil
 }
+func (m *mockBenchmarkStore) ListRunCycles(ctx context.Context, loc *time.Location, limit, offset int) ([]time.Time, error) {
+	return nil, nil
+}
+func (m *mockBenchmarkStore) QueryRunsInWindow(ctx context.Context, since, until time.Time) ([]store.BenchmarkRun, error) {
+	return nil, nil
+}
 func (m *mockBenchmarkStore) Close() error { return nil }
 
 // Verify JSON round-trip for Event metadata using stdlib json.

--- a/internal/store/sqlite/benchmark_store.go
+++ b/internal/store/sqlite/benchmark_store.go
@@ -428,6 +428,82 @@ func scanBenchmarkRun(row rowScanner) (*store.BenchmarkRun, error) {
 	return &run, nil
 }
 
+// ListRunCycles returns the distinct week-start timestamps (Sunday 00:00 in loc, stored as UTC)
+// for all benchmark runs, ordered newest first.
+// limit=0 returns all; offset skips the first N cycle rows.
+func (bs *BenchmarkStore) ListRunCycles(ctx context.Context, loc *time.Location, limit, offset int) ([]time.Time, error) {
+	if loc == nil {
+		loc = time.Local
+	}
+
+	// Pull all distinct run_at values (milliseconds UTC).
+	// We compute week-start grouping in Go so we can use the caller's local timezone
+	// (SQLite has no timezone support, and strftime('%w') is UTC-only).
+	const q = `SELECT DISTINCT run_at FROM benchmark_runs ORDER BY run_at DESC`
+	rows, err := bs.readDB.QueryContext(ctx, q)
+	if err != nil {
+		return nil, fmt.Errorf("list run_at for cycles: %w", err)
+	}
+	defer rows.Close()
+
+	// Collect unique week-start times in loc.
+	seen := make(map[time.Time]struct{})
+	var ordered []time.Time // insertion order = newest first (since query is DESC)
+	for rows.Next() {
+		var ms int64
+		if err := rows.Scan(&ms); err != nil {
+			return nil, fmt.Errorf("scan run_at: %w", err)
+		}
+		t := time.UnixMilli(ms).In(loc)
+		ws := weekStartInLoc(t)
+		if _, ok := seen[ws]; !ok {
+			seen[ws] = struct{}{}
+			ordered = append(ordered, ws)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate run_at rows: %w", err)
+	}
+
+	// Apply offset and limit.
+	if offset >= len(ordered) {
+		return nil, nil
+	}
+	ordered = ordered[offset:]
+	if limit > 0 && limit < len(ordered) {
+		ordered = ordered[:limit]
+	}
+	return ordered, nil
+}
+
+// weekStartInLoc returns midnight Sunday of the week containing t, in the same location as t.
+// Sunday is weekday 0 in Go's time.Weekday().
+func weekStartInLoc(t time.Time) time.Time {
+	// Shift back to Sunday.
+	daysBack := int(t.Weekday()) // Sunday=0, Monday=1, … Saturday=6
+	d := t.AddDate(0, 0, -daysBack)
+	return time.Date(d.Year(), d.Month(), d.Day(), 0, 0, 0, 0, d.Location())
+}
+
+// QueryRunsInWindow returns all benchmark runs whose run_at falls within [since, until),
+// ordered by run_at DESC.
+func (bs *BenchmarkStore) QueryRunsInWindow(ctx context.Context, since, until time.Time) ([]store.BenchmarkRun, error) {
+	const q = `SELECT id, run_at, window_days, agent_id, model,
+		accuracy, avg_latency_ms, p50_latency_ms, p95_latency_ms, p99_latency_ms,
+		tool_success_rate, roi_score, total_cost_usd, sample_size,
+		verdict, recommended_model, decision_reason, artifact_path, avg_quality_score
+		FROM benchmark_runs
+		WHERE run_at >= ? AND run_at < ?
+		ORDER BY run_at DESC`
+
+	rows, err := bs.readDB.QueryContext(ctx, q, since.UTC().UnixMilli(), until.UTC().UnixMilli())
+	if err != nil {
+		return nil, fmt.Errorf("query runs in window: %w", err)
+	}
+	defer rows.Close()
+	return scanBenchmarkRuns(rows)
+}
+
 // GetVerdictTrend returns the last N weekly verdicts for the given agent, ordered oldest first.
 // Returns an empty slice if the agent has no runs or fewer than requested.
 func (bs *BenchmarkStore) GetVerdictTrend(ctx context.Context, agentID string, weeks int) ([]string, error) {

--- a/internal/store/sqlite/benchmark_store_test.go
+++ b/internal/store/sqlite/benchmark_store_test.go
@@ -553,3 +553,253 @@ func TestSaveRunWithAllVerdicts(t *testing.T) {
 		t.Errorf("expected %d runs, got %d", len(verdicts), len(runs))
 	}
 }
+
+// ─── Cycle pagination tests ───────────────────────────────────────────────────
+
+// TestListRunCyclesEmpty verifies ListRunCycles returns nil/empty for an empty store.
+func TestListRunCyclesEmpty(t *testing.T) {
+	ctx := context.Background()
+	bs := newTestBenchmarkStore(t)
+
+	cycles, err := bs.ListRunCycles(ctx, time.UTC, 0, 0)
+	if err != nil {
+		t.Fatalf("ListRunCycles on empty store: %v", err)
+	}
+	if len(cycles) != 0 {
+		t.Errorf("expected 0 cycles, got %d: %v", len(cycles), cycles)
+	}
+}
+
+// TestListRunCyclesSingleWeek verifies that multiple runs in the same week collapse to one cycle.
+func TestListRunCyclesSingleWeek(t *testing.T) {
+	ctx := context.Background()
+	bs := newTestBenchmarkStore(t)
+
+	// Sunday 2024-01-07 — pick a known Sunday in UTC.
+	sunday := time.Date(2024, 1, 7, 10, 0, 0, 0, time.UTC)
+	// Two runs on the same Sunday-week (Sun 7th and Wed 10th).
+	for _, offset := range []time.Duration{0, 72 * time.Hour} {
+		r := sampleRun("cycle-agent", store.VerdictKeep)
+		r.RunAt = sunday.Add(offset)
+		if err := bs.SaveRun(ctx, r); err != nil {
+			t.Fatalf("SaveRun: %v", err)
+		}
+	}
+
+	cycles, err := bs.ListRunCycles(ctx, time.UTC, 0, 0)
+	if err != nil {
+		t.Fatalf("ListRunCycles: %v", err)
+	}
+	if len(cycles) != 1 {
+		t.Fatalf("expected 1 cycle (same week), got %d: %v", len(cycles), cycles)
+	}
+	// The cycle start should be Sunday 2024-01-07 00:00 UTC.
+	want := time.Date(2024, 1, 7, 0, 0, 0, 0, time.UTC)
+	if !cycles[0].Equal(want) {
+		t.Errorf("cycle start: got %v, want %v", cycles[0], want)
+	}
+}
+
+// TestListRunCyclesMultipleWeeks verifies that runs in different weeks yield distinct cycles, newest first.
+func TestListRunCyclesMultipleWeeks(t *testing.T) {
+	ctx := context.Background()
+	bs := newTestBenchmarkStore(t)
+
+	// Three runs each in a different ISO week (all Wednesdays, 1 week apart).
+	// Week starts: 2024-01-07 (Sun), 2024-01-14 (Sun), 2024-01-21 (Sun).
+	timestamps := []time.Time{
+		time.Date(2024, 1, 10, 12, 0, 0, 0, time.UTC), // Wed week-of-Jan-7
+		time.Date(2024, 1, 17, 12, 0, 0, 0, time.UTC), // Wed week-of-Jan-14
+		time.Date(2024, 1, 24, 12, 0, 0, 0, time.UTC), // Wed week-of-Jan-21
+	}
+	for i, ts := range timestamps {
+		r := sampleRun("multi-agent", store.VerdictKeep)
+		r.RunAt = ts
+		r.Accuracy = float64(i) * 0.1
+		if err := bs.SaveRun(ctx, r); err != nil {
+			t.Fatalf("SaveRun[%d]: %v", i, err)
+		}
+	}
+
+	cycles, err := bs.ListRunCycles(ctx, time.UTC, 0, 0)
+	if err != nil {
+		t.Fatalf("ListRunCycles: %v", err)
+	}
+	if len(cycles) != 3 {
+		t.Fatalf("expected 3 cycles, got %d: %v", len(cycles), cycles)
+	}
+
+	// Newest first: Jan-21 week, then Jan-14 week, then Jan-7 week.
+	wantStarts := []time.Time{
+		time.Date(2024, 1, 21, 0, 0, 0, 0, time.UTC),
+		time.Date(2024, 1, 14, 0, 0, 0, 0, time.UTC),
+		time.Date(2024, 1, 7, 0, 0, 0, 0, time.UTC),
+	}
+	for i, want := range wantStarts {
+		if !cycles[i].Equal(want) {
+			t.Errorf("cycles[%d]: got %v, want %v", i, cycles[i], want)
+		}
+	}
+}
+
+// TestListRunCyclesOffsetAndLimit verifies ListRunCycles applies offset and limit correctly.
+func TestListRunCyclesOffsetAndLimit(t *testing.T) {
+	ctx := context.Background()
+	bs := newTestBenchmarkStore(t)
+
+	// Insert runs in 5 different weeks.
+	for i := 0; i < 5; i++ {
+		r := sampleRun("ol-agent", store.VerdictKeep)
+		// Use Sundays separated by one week each.
+		r.RunAt = time.Date(2024, 1, 7+i*7, 10, 0, 0, 0, time.UTC)
+		if err := bs.SaveRun(ctx, r); err != nil {
+			t.Fatalf("SaveRun[%d]: %v", i, err)
+		}
+	}
+
+	// limit=2, offset=1 — skip the newest, return next 2.
+	cycles, err := bs.ListRunCycles(ctx, time.UTC, 2, 1)
+	if err != nil {
+		t.Fatalf("ListRunCycles: %v", err)
+	}
+	if len(cycles) != 2 {
+		t.Fatalf("expected 2 cycles with limit=2 offset=1, got %d", len(cycles))
+	}
+	// 5 Sundays newest-first: Jan-35(=Feb-4), Jan-28, Jan-21, Jan-14, Jan-7.
+	// offset=1 skips Feb-4; first result should be Jan-28.
+	wantFirst := time.Date(2024, 1, 28, 0, 0, 0, 0, time.UTC)
+	if !cycles[0].Equal(wantFirst) {
+		t.Errorf("cycles[0] after offset=1: got %v, want %v", cycles[0], wantFirst)
+	}
+}
+
+// TestQueryRunsInWindow verifies QueryRunsInWindow includes [since,until) correctly.
+func TestQueryRunsInWindow(t *testing.T) {
+	ctx := context.Background()
+	bs := newTestBenchmarkStore(t)
+
+	// Window: [2024-01-07, 2024-01-14)
+	since := time.Date(2024, 1, 7, 0, 0, 0, 0, time.UTC)
+	until := since.AddDate(0, 0, 7)
+
+	// Run inside the window.
+	inside := sampleRun("win-agent", store.VerdictKeep)
+	inside.RunAt = time.Date(2024, 1, 10, 12, 0, 0, 0, time.UTC)
+
+	// Run at the exact start boundary (inclusive).
+	atStart := sampleRun("win-agent", store.VerdictSwitch)
+	atStart.RunAt = since
+
+	// Run at exactly the end boundary (exclusive — must NOT appear).
+	atEnd := sampleRun("win-agent", store.VerdictUrgentSwitch)
+	atEnd.RunAt = until
+
+	// Run outside the window (before).
+	before := sampleRun("win-agent", store.VerdictKeep)
+	before.RunAt = time.Date(2024, 1, 5, 12, 0, 0, 0, time.UTC)
+
+	for _, r := range []store.BenchmarkRun{inside, atStart, atEnd, before} {
+		if err := bs.SaveRun(ctx, r); err != nil {
+			t.Fatalf("SaveRun: %v", err)
+		}
+	}
+
+	runs, err := bs.QueryRunsInWindow(ctx, since, until)
+	if err != nil {
+		t.Fatalf("QueryRunsInWindow: %v", err)
+	}
+	// Should contain exactly 'inside' and 'atStart'; 'atEnd' and 'before' excluded.
+	if len(runs) != 2 {
+		t.Fatalf("expected 2 runs in window, got %d: %v", len(runs), runs)
+	}
+	for _, r := range runs {
+		if !r.RunAt.Before(until) {
+			t.Errorf("run at %v is not before until %v — exclusive upper bound violated", r.RunAt, until)
+		}
+		if r.RunAt.Before(since) {
+			t.Errorf("run at %v is before since %v — inclusive lower bound violated", r.RunAt, since)
+		}
+	}
+}
+
+// TestQueryRunsInWindowEmpty verifies QueryRunsInWindow returns empty when no runs fall in window.
+func TestQueryRunsInWindowEmpty(t *testing.T) {
+	ctx := context.Background()
+	bs := newTestBenchmarkStore(t)
+
+	since := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	until := since.AddDate(0, 0, 7)
+
+	// Insert a run outside the window.
+	r := sampleRun("empty-win", store.VerdictKeep)
+	r.RunAt = time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	if err := bs.SaveRun(ctx, r); err != nil {
+		t.Fatalf("SaveRun: %v", err)
+	}
+
+	runs, err := bs.QueryRunsInWindow(ctx, since, until)
+	if err != nil {
+		t.Fatalf("QueryRunsInWindow: %v", err)
+	}
+	if len(runs) != 0 {
+		t.Errorf("expected 0 runs, got %d", len(runs))
+	}
+}
+
+// TestWeekStartInLoc verifies the week-start calculation for various weekdays.
+func TestWeekStartInLoc(t *testing.T) {
+	// We test via ListRunCycles with a single run placed on each weekday,
+	// verifying all collapse to the same Sunday week-start.
+
+	ctx := context.Background()
+
+	// Week containing 2024-01-07 (Sunday) through 2024-01-13 (Saturday).
+	expectedStart := time.Date(2024, 1, 7, 0, 0, 0, 0, time.UTC)
+
+	weekdays := []time.Time{
+		time.Date(2024, 1, 7, 8, 0, 0, 0, time.UTC),    // Sunday
+		time.Date(2024, 1, 8, 8, 0, 0, 0, time.UTC),    // Monday
+		time.Date(2024, 1, 10, 8, 0, 0, 0, time.UTC),   // Wednesday
+		time.Date(2024, 1, 13, 23, 59, 0, 0, time.UTC), // Saturday
+	}
+
+	for _, ts := range weekdays {
+		bs := newTestBenchmarkStore(t)
+		r := sampleRun("ws-agent", store.VerdictKeep)
+		r.RunAt = ts
+		if err := bs.SaveRun(ctx, r); err != nil {
+			t.Fatalf("SaveRun for %v: %v", ts, err)
+		}
+		cycles, err := bs.ListRunCycles(ctx, time.UTC, 0, 0)
+		if err != nil {
+			t.Fatalf("ListRunCycles for %v: %v", ts, err)
+		}
+		if len(cycles) != 1 {
+			t.Fatalf("expected 1 cycle for %v, got %d", ts, len(cycles))
+		}
+		if !cycles[0].Equal(expectedStart) {
+			t.Errorf("week-start for %v: got %v, want %v", ts, cycles[0], expectedStart)
+		}
+	}
+}
+
+// TestListRunCyclesNilLocDefaultsToLocal verifies that passing nil loc uses time.Local.
+func TestListRunCyclesNilLocDefaultsToLocal(t *testing.T) {
+	ctx := context.Background()
+	bs := newTestBenchmarkStore(t)
+
+	r := sampleRun("nil-loc", store.VerdictKeep)
+	r.RunAt = time.Now().UTC()
+	if err := bs.SaveRun(ctx, r); err != nil {
+		t.Fatalf("SaveRun: %v", err)
+	}
+
+	// nil loc should not panic.
+	cycles, err := bs.ListRunCycles(ctx, nil, 0, 0)
+	if err != nil {
+		t.Fatalf("ListRunCycles with nil loc: %v", err)
+	}
+	if len(cycles) != 1 {
+		t.Errorf("expected 1 cycle, got %d", len(cycles))
+	}
+}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -334,88 +334,115 @@ func makeRuns(n int) []store.BenchmarkRun {
 	return runs
 }
 
-// TestBenchmarkPageSizeIs20 verifies the page-size constant is 20.
-func TestBenchmarkPageSizeIs20(t *testing.T) {
-	if tui.BenchmarkPageSize != 20 {
-		t.Errorf("expected BenchmarkPageSize == 20, got %d", tui.BenchmarkPageSize)
+// makeCycles builds N week-start times (Sundays) going back N weeks from now.
+func makeCycles(n int) []time.Time {
+	cycles := make([]time.Time, n)
+	// Start from the most recent Sunday.
+	now := time.Now()
+	daysBack := int(now.Weekday())
+	lastSunday := now.AddDate(0, 0, -daysBack)
+	base := time.Date(lastSunday.Year(), lastSunday.Month(), lastSunday.Day(), 0, 0, 0, 0, time.Local)
+	for i := 0; i < n; i++ {
+		cycles[i] = base.AddDate(0, 0, -i*7)
 	}
+	return cycles
 }
 
-// TestBenchmarkViewRendersMax20Rows verifies that injecting 25 runs renders at most 20 rows.
-func TestBenchmarkViewRendersMax20Rows(t *testing.T) {
+// TestBenchmarkViewRendersAgentRows verifies that injecting runs renders the agent rows.
+func TestBenchmarkViewRendersAgentRows(t *testing.T) {
 	m := tui.NewBenchmarkModel(nil, "", "")
-	m, _ = m.Update(tui.BenchmarkDataMsg{Runs: makeRuns(25)})
+	m, _ = m.Update(tui.BenchmarkDataMsg{Runs: makeRuns(5)})
 
-	// Count table data rows by counting lines that contain "agent-" followed by a space
-	// (column padding) — this matches only table rows, not the detail panel.
 	view := m.View()
-	tableRowCount := 0
-	for _, line := range strings.Split(view, "\n") {
-		// Table data rows contain "agent-XX" padded with spaces to column width.
-		// The detail panel shows "Agent:    agent-XX" which won't match this pattern.
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "2026-") || strings.HasPrefix(trimmed, "-  ") {
-			// Lines starting with a date/time (data rows) or "-" (no-data rows).
-			if strings.Contains(trimmed, "agent-") {
-				tableRowCount++
-			}
-		}
-	}
-	if tableRowCount > 20 {
-		t.Errorf("expected at most 20 table data rows rendered, got %d", tableRowCount)
-	}
-	if tableRowCount == 0 {
-		t.Errorf("expected some rows rendered, got 0 (view: %q)", view)
+	// At least one agent row should appear.
+	if !strings.Contains(view, "agent-00") {
+		t.Errorf("expected 'agent-00' in view, got: %q", view)
 	}
 }
 
-// TestBenchmarkPgDnIncreasesPageOffset verifies PgDn moves pageOffset forward by one page.
-func TestBenchmarkPgDnIncreasesPageOffset(t *testing.T) {
+// TestBenchmarkCycleIndexStartsAtZero verifies cycleIndex is 0 initially.
+func TestBenchmarkCycleIndexStartsAtZero(t *testing.T) {
 	m := tui.NewBenchmarkModel(nil, "", "")
-	// Inject data so the model is not in loading state.
-	m, _ = m.Update(tui.BenchmarkDataMsg{Runs: makeRuns(20)})
-
-	initialOffset := tui.GetBenchmarkPageOffset(m)
-	if initialOffset != 0 {
-		t.Fatalf("expected initial pageOffset = 0, got %d", initialOffset)
-	}
-
-	// Send PgDn.
-	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyPgDown})
-	afterOffset := tui.GetBenchmarkPageOffset(m)
-	if afterOffset != tui.BenchmarkPageSize {
-		t.Errorf("after PgDn: expected pageOffset = %d, got %d", tui.BenchmarkPageSize, afterOffset)
+	if tui.GetBenchmarkCycleIndex(m) != 0 {
+		t.Errorf("expected initial cycleIndex = 0, got %d", tui.GetBenchmarkCycleIndex(m))
 	}
 }
 
-// TestBenchmarkPgUpDecreasesPageOffset verifies PgUp moves pageOffset backward without underflow.
-func TestBenchmarkPgUpDecreasesPageOffset(t *testing.T) {
+// TestBenchmarkPgDnAdvancesCycleIndex verifies PgDn moves to the next (older) cycle.
+func TestBenchmarkPgDnAdvancesCycleIndex(t *testing.T) {
 	m := tui.NewBenchmarkModel(nil, "", "")
-	m, _ = m.Update(tui.BenchmarkDataMsg{Runs: makeRuns(20)})
+	// Inject 3 cycles so PgDn has room to move.
+	cycles := makeCycles(3)
+	m, _ = m.Update(tui.BenchmarkDataMsg{
+		Runs:   makeRuns(3),
+		Cycles: cycles,
+	})
 
-	// Simulate two PgDn presses to get pageOffset = 2*pageSize.
+	if tui.GetBenchmarkCycleIndex(m) != 0 {
+		t.Fatalf("expected initial cycleIndex = 0, got %d", tui.GetBenchmarkCycleIndex(m))
+	}
+
+	// PgDn → cycleIndex = 1.
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyPgDown})
+	if tui.GetBenchmarkCycleIndex(m) != 1 {
+		t.Errorf("after PgDn: expected cycleIndex = 1, got %d", tui.GetBenchmarkCycleIndex(m))
+	}
+}
+
+// TestBenchmarkPgUpDecreaseCycleIndex verifies PgUp moves to the previous (newer) cycle without underflow.
+func TestBenchmarkPgUpDecreaseCycleIndex(t *testing.T) {
+	m := tui.NewBenchmarkModel(nil, "", "")
+	cycles := makeCycles(3)
+	m, _ = m.Update(tui.BenchmarkDataMsg{
+		Runs:   makeRuns(3),
+		Cycles: cycles,
+	})
+
+	// Two PgDn presses → cycleIndex = 2 (last cycle).
 	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyPgDown})
 	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyPgDown})
-	if tui.GetBenchmarkPageOffset(m) != 2*tui.BenchmarkPageSize {
-		t.Fatalf("setup: expected pageOffset = %d, got %d", 2*tui.BenchmarkPageSize, tui.GetBenchmarkPageOffset(m))
+	if tui.GetBenchmarkCycleIndex(m) != 2 {
+		t.Fatalf("setup: expected cycleIndex = 2, got %d", tui.GetBenchmarkCycleIndex(m))
 	}
 
-	// One PgUp should subtract one page.
+	// One PgUp → cycleIndex = 1.
 	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyPgUp})
-	if tui.GetBenchmarkPageOffset(m) != tui.BenchmarkPageSize {
-		t.Errorf("after PgUp: expected pageOffset = %d, got %d", tui.BenchmarkPageSize, tui.GetBenchmarkPageOffset(m))
+	if tui.GetBenchmarkCycleIndex(m) != 1 {
+		t.Errorf("after PgUp: expected cycleIndex = 1, got %d", tui.GetBenchmarkCycleIndex(m))
 	}
 
-	// Another PgUp should go to 0, not negative.
+	// Another PgUp → cycleIndex = 0.
 	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyPgUp})
-	if tui.GetBenchmarkPageOffset(m) != 0 {
-		t.Errorf("after second PgUp: expected pageOffset = 0, got %d", tui.GetBenchmarkPageOffset(m))
+	if tui.GetBenchmarkCycleIndex(m) != 0 {
+		t.Errorf("after second PgUp: expected cycleIndex = 0, got %d", tui.GetBenchmarkCycleIndex(m))
 	}
 
-	// A third PgUp should stay at 0.
+	// Third PgUp at 0 → stays at 0 (no underflow).
 	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyPgUp})
-	if tui.GetBenchmarkPageOffset(m) != 0 {
-		t.Errorf("after third PgUp from 0: expected pageOffset = 0, got %d", tui.GetBenchmarkPageOffset(m))
+	if tui.GetBenchmarkCycleIndex(m) != 0 {
+		t.Errorf("after third PgUp from 0: expected cycleIndex = 0, got %d", tui.GetBenchmarkCycleIndex(m))
+	}
+}
+
+// TestBenchmarkPgDnAtLastCycleDoesNotAdvance verifies PgDn at the last cycle is a no-op.
+func TestBenchmarkPgDnAtLastCycleDoesNotAdvance(t *testing.T) {
+	m := tui.NewBenchmarkModel(nil, "", "")
+	cycles := makeCycles(2)
+	m, _ = m.Update(tui.BenchmarkDataMsg{
+		Runs:   makeRuns(2),
+		Cycles: cycles,
+	})
+
+	// Move to last cycle.
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyPgDown})
+	if tui.GetBenchmarkCycleIndex(m) != 1 {
+		t.Fatalf("expected cycleIndex = 1, got %d", tui.GetBenchmarkCycleIndex(m))
+	}
+
+	// Another PgDn at last cycle → stays at 1.
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyPgDown})
+	if tui.GetBenchmarkCycleIndex(m) != 1 {
+		t.Errorf("PgDn at last cycle should not advance: got cycleIndex = %d", tui.GetBenchmarkCycleIndex(m))
 	}
 }
 
@@ -564,7 +591,8 @@ func TestBenchmarkViewShowsDateAndTime(t *testing.T) {
 // TestBenchmarkPgDnResetsCursor verifies PgDn resets cursor to 0.
 func TestBenchmarkPgDnResetsCursor(t *testing.T) {
 	m := tui.NewBenchmarkModel(nil, "", "")
-	m, _ = m.Update(tui.BenchmarkDataMsg{Runs: makeRuns(5)})
+	cycles := makeCycles(3)
+	m, _ = m.Update(tui.BenchmarkDataMsg{Runs: makeRuns(5), Cycles: cycles})
 
 	// Move cursor to row 3.
 	for i := 0; i < 3; i++ {

--- a/internal/tui/benchmark_view.go
+++ b/internal/tui/benchmark_view.go
@@ -17,9 +17,6 @@ import (
 	"github.com/kiosvantra/metronous/internal/store"
 )
 
-// maxBenchmarkRows is the maximum number of rows to fetch per page in the benchmark tab.
-const maxBenchmarkRows = 20
-
 // benchmarkRefreshInterval is the auto-refresh period for the benchmark tab,
 // matching the tracking tab's cadence.
 const benchmarkRefreshInterval = 2 * time.Second
@@ -30,6 +27,7 @@ type benchmarkTickMsg struct{ t time.Time }
 // BenchmarkDataMsg carries fetched benchmark runs.
 type BenchmarkDataMsg struct {
 	Runs      []store.BenchmarkRun
+	Cycles    []time.Time         // week-start timestamps, newest first (nil = no change)
 	TypeByID  map[string]string   // agentID → type label (primary/subagent/built-in/all)
 	TrendByID map[string][]string // agentID → verdict trend (oldest first)
 	Err       error
@@ -94,18 +92,20 @@ func loadModelPricing(dataDir string) map[string]float64 {
 // BenchmarkModel is the Bubble Tea sub-model for the benchmark history tab.
 type BenchmarkModel struct {
 	bs        store.BenchmarkStore
-	runs      []store.BenchmarkRun
+	runs      []store.BenchmarkRun // rows for the current cycle (one per agent, placeholder if no run)
 	agents    []discovery.AgentInfo
 	typeByID  map[string]string   // agentID → type label (primary/subagent/built-in/all)
 	trendByID map[string][]string // agentID → verdict trend (oldest first)
 	err       error
-	// cursor is the local row index within the current page (0..maxBenchmarkRows-1).
+	// cursor is the row index within the current cycle's agent list.
 	cursor  int
 	loading bool
-	// pageOffset is the number of runs skipped from the top (run_at DESC).
-	// PgDn increases pageOffset (moves toward older runs).
-	// PgUp decreases pageOffset (moves toward newer runs).
-	pageOffset int
+	// cycles is the ordered list of week-start times (newest first) discovered in the DB.
+	cycles []time.Time
+	// cycleIndex is the index into cycles currently displayed (0 = newest cycle).
+	// PgDn increases cycleIndex (moves toward older cycles).
+	// PgUp decreases cycleIndex (moves toward newer cycles).
+	cycleIndex int
 	// detailFrozen indicates whether the detail panel is locked to frozenRun/frozenTrend.
 	// When true, the detail does not update even if the background refresh changes m.runs.
 	detailFrozen bool
@@ -157,12 +157,14 @@ func (m BenchmarkModel) Update(msg tea.Msg) (BenchmarkModel, tea.Cmd) {
 		m.loading = false
 		m.err = msg.Err
 		if msg.Err == nil {
-			// Enforce page size — the view always renders at most maxBenchmarkRows rows.
-			runs := msg.Runs
-			if len(runs) > maxBenchmarkRows {
-				runs = runs[:maxBenchmarkRows]
+			m.runs = msg.Runs
+			if msg.Cycles != nil {
+				m.cycles = msg.Cycles
+				// Clamp cycleIndex to valid range when cycles change.
+				if m.cycleIndex >= len(m.cycles) && len(m.cycles) > 0 {
+					m.cycleIndex = len(m.cycles) - 1
+				}
 			}
-			m.runs = runs
 			if msg.TypeByID != nil {
 				m.typeByID = msg.TypeByID
 			}
@@ -183,35 +185,35 @@ func (m BenchmarkModel) Update(msg tea.Msg) (BenchmarkModel, tea.Cmd) {
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "up", "k":
-			// Move selection one row up within the current page.
+			// Move selection one row up within the current cycle.
 			if m.cursor > 0 {
 				m.cursor--
 			}
 			// Unfreeze detail so it follows the cursor.
 			m.detailFrozen = false
 		case "down", "j":
-			// Move selection one row down within the current page.
+			// Move selection one row down within the current cycle.
 			if m.cursor < len(m.runs)-1 {
 				m.cursor++
 			}
 			// Unfreeze detail so it follows the cursor.
 			m.detailFrozen = false
 		case "pgdown":
-			// Slide window toward older runs (increase pageOffset by one full page).
-			m.pageOffset += maxBenchmarkRows
-			m.cursor = 0
-			m.detailFrozen = false
-			return m, m.fetchRuns()
-		case "pgup":
-			// Slide window toward newer runs (decrease pageOffset by one full page).
-			if m.pageOffset >= maxBenchmarkRows {
-				m.pageOffset -= maxBenchmarkRows
-			} else {
-				m.pageOffset = 0
+			// Move to the next (older) cycle.
+			if m.cycleIndex < len(m.cycles)-1 {
+				m.cycleIndex++
+				m.cursor = 0
+				m.detailFrozen = false
+				return m, m.fetchRuns()
 			}
-			m.cursor = 0
-			m.detailFrozen = false
-			return m, m.fetchRuns()
+		case "pgup":
+			// Move to the previous (newer) cycle.
+			if m.cycleIndex > 0 {
+				m.cycleIndex--
+				m.cursor = 0
+				m.detailFrozen = false
+				return m, m.fetchRuns()
+			}
 		case "enter":
 			// Freeze the detail panel on the currently selected run.
 			if m.cursor >= 0 && m.cursor < len(m.runs) {
@@ -245,39 +247,40 @@ func agentTypeOrder(t string) int {
 	}
 }
 
-// fetchRuns returns a command that queries all discovered agents' latest runs.
-// Agents with no data are included as placeholder rows (Verdict == "").
-// The pageOffset field controls which window of sorted rows is returned.
+// fetchRuns returns a command that builds the current cycle's agent rows.
+// Each cycle corresponds to one Sunday-bounded week in local time.
+// All agents (discovered + DB) appear; agents with no run in the cycle get a NO RUN placeholder.
 func (m BenchmarkModel) fetchRuns() tea.Cmd {
 	if m.bs == nil {
 		return nil
 	}
-	// Snapshot the agent list and pageOffset at scheduling time so the closure is self-contained.
+	// Snapshot mutable state so the closure is self-contained.
 	agents := m.agents
-	pageOffset := m.pageOffset
+	cycleIndex := m.cycleIndex
+	knownCycles := m.cycles
+	loc := time.Local
+
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
-		// Build a map of agent types from the discovered agent list.
+		// ── 1. Build typeByID from discovered agents + DB agents ──────────────
 		typeByID := make(map[string]string, len(agents))
 		for _, a := range agents {
 			typeByID[a.ID] = a.Type
 		}
 
-		// Also pick up any agents that have runs in the DB but were not
-		// discovered via config files (e.g. agents from old sessions).
 		dbAgents, err := m.bs.ListAgents(ctx)
 		if err != nil {
 			return BenchmarkDataMsg{Err: err}
 		}
 		for _, id := range dbAgents {
 			if _, found := typeByID[id]; !found {
-				typeByID[id] = "primary" // default type for DB-only agents
+				typeByID[id] = "primary"
 			}
 		}
 
-		// Merge discovered and DB agent IDs into a unified set.
+		// Merge into ordered allIDs (discovered first, then DB-only).
 		seen := make(map[string]bool)
 		var allIDs []string
 		for _, a := range agents {
@@ -293,40 +296,74 @@ func (m BenchmarkModel) fetchRuns() tea.Cmd {
 			}
 		}
 
-		// Build one row per agent (latest run only).
-		var all []store.BenchmarkRun
-		for _, agentID := range allIDs {
-			runs, err := m.bs.GetRuns(ctx, agentID, 1)
-			if err != nil || len(runs) == 0 {
-				// No data yet — create a placeholder row.
-				all = append(all, store.BenchmarkRun{AgentID: agentID})
-				continue
-			}
-			all = append(all, runs[0])
+		// ── 2. Fetch/refresh cycle list ───────────────────────────────────────
+		cycles, err := m.bs.ListRunCycles(ctx, loc, 0, 0)
+		if err != nil {
+			return BenchmarkDataMsg{Err: err}
+		}
+		// Fall back to previously known cycles so the UI stays consistent while
+		// the store hasn't written any runs yet.
+		if len(cycles) == 0 && len(knownCycles) > 0 {
+			cycles = knownCycles
 		}
 
-		// Sort rows: primary → subagent → all → built-in, then alphabetical within each group.
-		sort.Slice(all, func(i, j int) bool {
-			ti := agentTypeOrder(typeByID[all[i].AgentID])
-			tj := agentTypeOrder(typeByID[all[j].AgentID])
+		// ── 3. Determine the active cycle window ──────────────────────────────
+		// cycleIndex 0 = newest cycle; clamp to valid range.
+		if cycleIndex < 0 {
+			cycleIndex = 0
+		}
+		if cycleIndex >= len(cycles) && len(cycles) > 0 {
+			cycleIndex = len(cycles) - 1
+		}
+
+		var (
+			cycleStart time.Time
+			cycleEnd   time.Time
+		)
+		if len(cycles) > 0 {
+			cycleStart = cycles[cycleIndex]
+			cycleEnd = cycleStart.AddDate(0, 0, 7)
+		}
+
+		// ── 4. Fetch runs in the active cycle window ──────────────────────────
+		var windowRuns []store.BenchmarkRun
+		if !cycleStart.IsZero() {
+			windowRuns, err = m.bs.QueryRunsInWindow(ctx, cycleStart.UTC(), cycleEnd.UTC())
+			if err != nil {
+				return BenchmarkDataMsg{Err: err}
+			}
+		}
+
+		// Build a lookup: agentID → run in this cycle (last run if multiple per agent per cycle).
+		runByAgent := make(map[string]store.BenchmarkRun, len(windowRuns))
+		for _, r := range windowRuns {
+			if existing, ok := runByAgent[r.AgentID]; !ok || r.RunAt.After(existing.RunAt) {
+				runByAgent[r.AgentID] = r
+			}
+		}
+
+		// ── 5. Build one row per agent (NO RUN placeholder if absent) ─────────
+		var page []store.BenchmarkRun
+		for _, agentID := range allIDs {
+			if run, ok := runByAgent[agentID]; ok {
+				page = append(page, run)
+			} else {
+				// Placeholder: AgentID set, RunAt zero → isNoData() returns true.
+				page = append(page, store.BenchmarkRun{AgentID: agentID})
+			}
+		}
+
+		// Sort: primary → subagent → all → built-in, then alphabetical.
+		sort.Slice(page, func(i, j int) bool {
+			ti := agentTypeOrder(typeByID[page[i].AgentID])
+			tj := agentTypeOrder(typeByID[page[j].AgentID])
 			if ti != tj {
 				return ti < tj
 			}
-			return all[i].AgentID < all[j].AgentID
+			return page[i].AgentID < page[j].AgentID
 		})
 
-		// Apply sliding-window pagination: slice out the current page.
-		start := pageOffset
-		if start > len(all) {
-			start = len(all)
-		}
-		end := start + maxBenchmarkRows
-		if end > len(all) {
-			end = len(all)
-		}
-		page := all[start:end]
-
-		// Fetch verdict trends for each agent in the current page (last 8 weeks).
+		// ── 6. Fetch verdict trends for each agent in the page (last 8 weeks) ─
 		trendByID := make(map[string][]string, len(page))
 		for _, run := range page {
 			trend, err := m.bs.GetVerdictTrend(ctx, run.AgentID, 8)
@@ -335,7 +372,7 @@ func (m BenchmarkModel) fetchRuns() tea.Cmd {
 			}
 		}
 
-		return BenchmarkDataMsg{Runs: page, TypeByID: typeByID, TrendByID: trendByID}
+		return BenchmarkDataMsg{Runs: page, Cycles: cycles, TypeByID: typeByID, TrendByID: trendByID}
 	}
 }
 
@@ -406,11 +443,19 @@ func (m BenchmarkModel) View() string {
 		sb.WriteString("\n")
 	}
 
-	// Pagination footer.
+	// Pagination footer: show cycle number (1-based from newest).
 	sb.WriteString("\n")
-	pageNum := m.pageOffset/maxBenchmarkRows + 1
-	footer := fmt.Sprintf("  %d entries shown  |  page %d  (PgUp/PgDn to navigate, ↑↓ to select, Enter to freeze detail)",
-		len(m.runs), pageNum)
+	totalCycles := len(m.cycles)
+	var cycleLabel string
+	if totalCycles > 0 {
+		cycleStart := m.cycles[m.cycleIndex]
+		cycleLabel = fmt.Sprintf("cycle %d/%d  (week of %s)",
+			m.cycleIndex+1, totalCycles, cycleStart.Local().Format("2006-01-02"))
+	} else {
+		cycleLabel = "cycle 1/1"
+	}
+	footer := fmt.Sprintf("  %d agents  |  %s  (PgUp/PgDn to change cycle, ↑↓ to select, Enter to freeze detail)",
+		len(m.runs), cycleLabel)
 	sb.WriteString(dimStyle.Render(footer))
 	sb.WriteString("\n")
 

--- a/internal/tui/export_test.go
+++ b/internal/tui/export_test.go
@@ -3,6 +3,8 @@
 package tui
 
 import (
+	"time"
+
 	"github.com/kiosvantra/metronous/internal/config"
 	"github.com/kiosvantra/metronous/internal/store"
 )
@@ -35,12 +37,14 @@ func TrendDirection(verdicts []string) string {
 	return trendDirection(verdicts)
 }
 
-// BenchmarkPageSize exposes maxBenchmarkRows for pagination tests.
-const BenchmarkPageSize = maxBenchmarkRows
+// GetBenchmarkCycleIndex returns the current cycleIndex for tests.
+func GetBenchmarkCycleIndex(m BenchmarkModel) int {
+	return m.cycleIndex
+}
 
-// GetBenchmarkPageOffset returns the current pageOffset for tests.
-func GetBenchmarkPageOffset(m BenchmarkModel) int {
-	return m.pageOffset
+// GetBenchmarkCycles returns the list of cycle week-starts for tests.
+func GetBenchmarkCycles(m BenchmarkModel) []time.Time {
+	return m.cycles
 }
 
 // GetBenchmarkCursor returns the current cursor for tests.


### PR DESCRIPTION
Implements cycle-based pagination in Benchmark Detailed (Tab 3) using run_at grouped by week starting on Sunday (local time). Pages correspond to full cycles; PgUp/PgDn navigates between cycles; NO RUN rows render in grey.